### PR TITLE
implemented #11 and #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ func main() {
 	mux.Handle("/proxy", handleProxy) // http://localhost:8080/proxy
 	mux.Handle("/agent", handleAgent) // http://localhost:8080/agent
 
-	log.Println("Listening...")
+	logger.Println("Listening...")
 	http.ListenAndServe(":8080", mux)
 }
 ```

--- a/README.md
+++ b/README.md
@@ -137,13 +137,11 @@ func main() {
 	proxy.Log = logger
 
 	// Prepare proxy handler and serve it at http://localhost:8080/proxy
-	handleProxy := http.HandlerFunc(proxy.Handler)
-	mux.Handle("/proxy", handleProxy) 
+	mux.HandleFunc("/proxy", proxy.Handler) 
 
 	// The handleAgent is only needed if you plan to serve the agent's WebID
 	// profile yourself; it will be available at http://localhost:8080/agent
-	handleAgent := http.HandlerFunc(agent.Handler)
-	mux.Handle("/agent", handleAgent) 
+	mux.HandleFunc("/agent", agent.Handler) 
 
 	logger.Println("Listening...")
 	http.ListenAndServe(":8080", mux)

--- a/README.md
+++ b/README.md
@@ -110,10 +110,6 @@ import (
 func main() {
 	mux := http.NewServeMux()
 
-	// Skip verifying trust chain for certificates?
-	// Use true when dealing with self-signed certs (testing, etc.)
-	insecureSkipVerify := true
-
 	// Init logger
 	logger := log.New(os.Stderr, "[debug] ", log.Flags()|log.Lshortfile)
 
@@ -124,10 +120,15 @@ func main() {
 		log.Println("Error creating new agent:", err.Error())
 		return
 	}
+	// assign logger
 	agent.Log = logger
-
+	
+	// Skip verifying trust chain for certificates?
+	// Use true when dealing with self-signed certs (testing, etc.)
+	insecureSkipVerify := true
 	// create a new proxy object
 	proxy := solidproxy.NewProxy(agent, insecureSkipVerify)
+	// assign logger
 	proxy.Log = logger
 
 	// init handlers
@@ -135,8 +136,8 @@ func main() {
 	handleAgent := http.HandlerFunc(agent.Handler)
 
 	// set handlers
-	mux.Handle("/proxy", handleProxy)
-	mux.Handle("/agent", handleAgent)
+	mux.Handle("/proxy", handleProxy) // http://localhost:8080/proxy
+	mux.Handle("/agent", handleAgent) // http://localhost:8080/agent
 
 	log.Println("Listening...")
 	http.ListenAndServe(":8080", mux)

--- a/handler.go
+++ b/handler.go
@@ -13,8 +13,6 @@ import (
 )
 
 var (
-	Logger *log.Logger
-
 	cookies  = map[string]map[string][]*http.Cookie{}
 	cookiesL = new(sync.RWMutex)
 )
@@ -29,9 +27,11 @@ func InitLogger(config *ServerConfig) *log.Logger {
 
 // NewServer creates a new server handler
 func NewProxyHandler(config *ServerConfig, proxy *Proxy) *echo.Echo {
-	Logger = InitLogger(config)
-	Logger.Println("\n---- starting proxy server ----")
-	Logger.Printf("config: %#v\n", config)
+	logger := InitLogger(config)
+	logger.Println("\n---- starting proxy server ----")
+	logger.Printf("config: %#v\n", config)
+
+	proxy.Log = logger
 
 	// Create new handler
 	handler := echo.New()
@@ -53,9 +53,10 @@ func NewProxyHandler(config *ServerConfig, proxy *Proxy) *echo.Echo {
 }
 
 func NewAgentHandler(config *ServerConfig, agent *Agent) *echo.Echo {
-	Logger = InitLogger(config)
-	Logger.Println("\n---- starting agent server ----")
-	Logger.Printf("config: %#v\n", config)
+	logger := InitLogger(config)
+	logger.Println("\n---- starting agent server ----")
+	logger.Printf("config: %#v\n", config)
+	agent.Log = logger
 
 	// Create new handler
 	handler := echo.New()

--- a/handler_test.go
+++ b/handler_test.go
@@ -24,7 +24,7 @@ func init() {
 	testAgentWebID = "https://example.com/webid#me"
 
 	// ** AGENT **
-	agent, err := NewAgent(testAgentWebID)
+	agent, err := NewAgentLocal(testAgentWebID)
 	if err != nil {
 		panic(err)
 	}

--- a/handler_test.go
+++ b/handler_test.go
@@ -62,18 +62,18 @@ func TestServerVersion(t *testing.T) {
 	assert.Equal(t, SERVER_VERSION, GetVersion())
 }
 
-func TestRouteNotImplemented(t *testing.T) {
+func TestRouteDoesNotExist(t *testing.T) {
 	req, err := http.NewRequest("GET", testAgentServer.URL, nil)
 	assert.NoError(t, err)
 	resp, err := testClient.Do(req)
 	assert.NoError(t, err)
-	assert.Equal(t, 501, resp.StatusCode)
+	assert.Equal(t, 404, resp.StatusCode)
 
 	req, err = http.NewRequest("GET", testProxyServer.URL, nil)
 	assert.NoError(t, err)
 	resp, err = testClient.Do(req)
 	assert.NoError(t, err)
-	assert.Equal(t, 501, resp.StatusCode)
+	assert.Equal(t, 404, resp.StatusCode)
 }
 
 func TestRouteWebID(t *testing.T) {

--- a/handler_test.go
+++ b/handler_test.go
@@ -14,29 +14,25 @@ var (
 	testProxyServer  *httptest.Server
 	testAgentServer  *httptest.Server
 	testClient       *http.Client
+	testAgentWebID   string
 )
 
 func init() {
 	var err error
+	skipVerify := true
 
-	testAgentWebID := "https://example.com/webid#me"
-
-	// ** PROXY **
-	proxyConf := NewServerConfig()
-	proxyConf.InsecureSkipVerify = true
-	proxyConf.Agent = testAgentWebID
-	proxyServer := NewProxyHandler(proxyConf)
-
-	// testProxyServer
-	testProxyServer = httptest.NewServer(proxyServer)
-	testProxyServer.URL = strings.Replace(testProxyServer.URL, "127.0.0.1", "localhost", 1)
+	testAgentWebID = "https://example.com/webid#me"
 
 	// ** AGENT **
+	agent, err := NewAgent(testAgentWebID)
+	if err != nil {
+		panic(err)
+	}
 	agentConf := NewServerConfig()
 	agentConf.TLSKey = "test_key.pem"
 	agentConf.TLSCert = "test_cert.pem"
 	agentConf.Agent = testAgentWebID
-	agentServer := NewAgentHandler(agentConf)
+	agentServer := NewAgentHandler(agentConf, agent)
 	// testProxyServer
 	testAgentServer = httptest.NewUnstartedServer(agentServer)
 	testAgentServer.TLS, err = NewTLSConfig(agentConf)
@@ -45,6 +41,17 @@ func init() {
 	}
 	testAgentServer.StartTLS()
 	testAgentServer.URL = strings.Replace(testAgentServer.URL, "127.0.0.1", "localhost", 1)
+
+	// ** PROXY **
+	proxy := NewProxy(agent, skipVerify)
+	proxyConf := NewServerConfig()
+	proxyConf.InsecureSkipVerify = skipVerify
+	proxyConf.Agent = testAgentWebID
+	proxyServer := NewProxyHandler(proxyConf, proxy)
+
+	// testProxyServer
+	testProxyServer = httptest.NewServer(proxyServer)
+	testProxyServer.URL = strings.Replace(testProxyServer.URL, "127.0.0.1", "localhost", 1)
 
 	// ** CLIENT **
 	// testClient

--- a/proxy-server/proxy-server.go
+++ b/proxy-server/proxy-server.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/labstack/echo"
 	"github.com/solid/solidproxy"
 )
 
@@ -96,11 +95,11 @@ func main() {
 
 	// Start servers
 	println("\nStarting SolidProxy", solidproxy.GetVersion())
-	go agentHandler.StartServer(agentServer)
-	proxyHandler.StartServer(proxyServer)
+	go agentServer.ListenAndServe()
+	proxyServer.ListenAndServe()
 }
 
-func NewServer(handler *echo.Echo, config *solidproxy.ServerConfig) (*http.Server, error) {
+func NewServer(handler http.Handler, config *solidproxy.ServerConfig) (*http.Server, error) {
 	// Create proxy server listener and set config values
 	var err error
 	s := &http.Server{

--- a/proxy-server/proxy-server.go
+++ b/proxy-server/proxy-server.go
@@ -59,9 +59,17 @@ func main() {
 		configAgent.Port = os.Getenv("SOLIDPROXY_AGENTPORT") // default= :3200
 	}
 
+	// Create new agent
+	agent, err := solidproxy.NewAgent(configAgent.Agent)
+	if err != nil {
+		println("Cannot create new agent:", err.Error())
+		return
+	}
+	proxy := solidproxy.NewProxy(agent, configAgent.InsecureSkipVerify)
+
 	// Create handlers
-	agentHandler := solidproxy.NewAgentHandler(configAgent)
-	proxyHandler := solidproxy.NewProxyHandler(configProxy)
+	agentHandler := solidproxy.NewAgentHandler(configAgent, agent)
+	proxyHandler := solidproxy.NewProxyHandler(configProxy, proxy)
 
 	// Create servers
 	agentServer, err := NewServer(agentHandler, configAgent)

--- a/proxy-server/proxy-server.go
+++ b/proxy-server/proxy-server.go
@@ -22,12 +22,12 @@ func main() {
 	configAgent.Port = "3200" // set default for agent
 
 	// logger
-	solidproxy.Logger = log.New(ioutil.Discard, "", 0)
+	logger := log.New(ioutil.Discard, "", 0)
 
 	if len(os.Getenv("SOLIDPROXY_VERBOSE")) > 0 {
 		configProxy.Verbose = true // default= false
 		configAgent.Verbose = true // default= false
-		solidproxy.Logger = log.New(os.Stderr, debugPrefix, debugFlags)
+		logger = log.New(os.Stderr, debugPrefix, debugFlags)
 	}
 	if len(os.Getenv("SOLIDPROXY_INSECURE")) > 0 {
 		configProxy.InsecureSkipVerify = true // default= false
@@ -60,12 +60,14 @@ func main() {
 	}
 
 	// Create new agent
-	agent, err := solidproxy.NewAgent(configAgent.Agent)
+	agent, err := solidproxy.NewAgentLocal(configAgent.Agent)
 	if err != nil {
 		println("Cannot create new agent:", err.Error())
 		return
 	}
+	agent.Log = logger
 	proxy := solidproxy.NewProxy(agent, configAgent.InsecureSkipVerify)
+	proxy.Log = logger
 
 	// Create handlers
 	agentHandler := solidproxy.NewAgentHandler(configAgent, agent)

--- a/proxy-server/proxy-server.go
+++ b/proxy-server/proxy-server.go
@@ -24,6 +24,15 @@ func main() {
 	// logger
 	logger := log.New(ioutil.Discard, "", 0)
 
+	// Try to recover in case of panics
+	defer func() {
+		if rec := recover(); rec != nil {
+			logger.Println(rec)
+			return
+		}
+	}()
+
+	// Read config from environment
 	if len(os.Getenv("SOLIDPROXY_VERBOSE")) > 0 {
 		configProxy.Verbose = true // default= false
 		configAgent.Verbose = true // default= false

--- a/proxy.go
+++ b/proxy.go
@@ -78,10 +78,10 @@ func (p *Proxy) Handler(w http.ResponseWriter, req *http.Request) {
 
 	// Retry with server credentials if authentication is required
 	if r.StatusCode == 401 && len(user) > 0 && p.HttpAgentClient != nil {
-		// for debugging
-		defer TimeTrack(time.Now(), "Fetching", p.Log)
+		// Log the time it takes to finish the request (for debugging)
+		defer TimeTrack(time.Now(), req.Method+" operation", p.Log)
 		// build new response
-		authenticated, err := http.NewRequest("GET", req.URL.String(), req.Body)
+		authenticated, err := http.NewRequest(req.Method, req.URL.String(), req.Body)
 		authenticated.Header.Set("On-Behalf-Of", user)
 		var solutionMsg string
 		var client *http.Client
@@ -110,7 +110,7 @@ func (p *Proxy) Handler(w http.ResponseWriter, req *http.Request) {
 		// Store cookies per user and request host
 		if len(r.Cookies()) > 0 {
 			cookiesL.Lock()
-			// Should store cookies based on domain value AND path from cookie
+			// TODO: should store cookies based on domain value AND path from cookie
 			cookies[user] = map[string][]*http.Cookie{}
 			cookies[user][req.Host] = r.Cookies()
 			p.Log.Printf("Cookies: %+v\n", cookies)

--- a/proxy.go
+++ b/proxy.go
@@ -3,6 +3,7 @@ package solidproxy
 import (
 	"crypto/tls"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/url"
 	"time"
@@ -16,24 +17,30 @@ const (
 type Proxy struct {
 	HttpClient      *http.Client
 	HttpAgentClient *http.Client
+	Log             *log.Logger
 	Agent           *Agent
 }
 
 func NewProxy(agent *Agent, skip bool) *Proxy {
-	return &Proxy{
-		HttpClient:      NewClient(skip),
-		HttpAgentClient: NewAgentClient(agent.Cert, skip),
-		Agent:           agent,
+	proxy := &Proxy{
+		HttpClient: NewClient(skip),
+		Agent:      agent,
 	}
+
+	if agent.Cert != nil {
+		proxy.HttpAgentClient = NewAgentClient(agent.Cert, skip)
+	}
+
+	return proxy
 }
 
 func (p *Proxy) Handler(w http.ResponseWriter, req *http.Request) {
-	Logger.Println("New request from:", req.RemoteAddr, "for URI:", req.URL.String())
+	p.Log.Println("New request from:", req.RemoteAddr, "for URI:", req.URL.String())
 
 	uri := req.FormValue("uri")
 	if len(uri) == 0 {
 		msg := "HTTP 400 - Bad Request. Please provide a URI to the proxy."
-		Logger.Println(msg, req.URL.String())
+		p.Log.Println(msg, req.URL.String())
 		w.WriteHeader(400)
 		w.Write([]byte(msg))
 		return
@@ -41,7 +48,7 @@ func (p *Proxy) Handler(w http.ResponseWriter, req *http.Request) {
 
 	resource, err := url.ParseRequestURI(uri)
 	if err != nil {
-		Logger.Println("Error parsing URL:", req.URL, err.Error())
+		p.Log.Println("Error parsing URL:", req.URL, err.Error())
 		w.WriteHeader(400)
 		w.Write([]byte("HTTP 400 - Bad Request. You must provide a valid URI: " + req.URL.String()))
 		return
@@ -53,7 +60,7 @@ func (p *Proxy) Handler(w http.ResponseWriter, req *http.Request) {
 	// get user
 	user := req.Header.Get("User")
 
-	Logger.Println("Proxying request for URI:", req.URL, "and user:", user)
+	p.Log.Println("Proxying request for URI:", req.URL, "and user:", user)
 
 	// build new response
 	// no error should exist at this point, it was caught earlier
@@ -63,18 +70,16 @@ func (p *Proxy) Handler(w http.ResponseWriter, req *http.Request) {
 
 	r, err := p.HttpClient.Do(plain)
 	if err != nil {
-		Logger.Println("Request execution error:", err)
+		p.Log.Println("Request execution error:", err)
 		w.WriteHeader(500)
 		w.Write([]byte(err.Error()))
 		return
 	}
-	// Close the connection to reuse it
-	defer r.Body.Close()
 
 	// Retry with server credentials if authentication is required
-	if r.StatusCode == 401 && len(user) > 0 {
+	if r.StatusCode == 401 && len(user) > 0 && p.HttpAgentClient != nil {
 		// for debugging
-		defer TimeTrack(time.Now(), "Fetching")
+		defer TimeTrack(time.Now(), "Fetching", p.Log)
 		// build new response
 		authenticated, err := http.NewRequest("GET", req.URL.String(), req.Body)
 		authenticated.Header.Set("On-Behalf-Of", user)
@@ -84,22 +89,22 @@ func (p *Proxy) Handler(w http.ResponseWriter, req *http.Request) {
 		if len(cookies[user]) > 0 { // Use existing cookie
 			authenticated.AddCookie(cookies[user][req.Host][0])
 			// Create the client
-			// client = NewClient(insecureSkipVerify)
 			client = p.HttpClient
 			solutionMsg = "Retrying with cookies"
 		} else { // Using WebIDTLS client
-			// client = NewAgentClient(agentCert)
 			client = p.HttpAgentClient
 			solutionMsg = "Retrying with WebID-TLS"
 		}
+		// Close the previous response to reuse the connection
+		r.Body.Close()
 		r, err = client.Do(authenticated)
 		if err != nil {
-			Logger.Println("Request execution error on auth retry:", err)
+			p.Log.Println("Request execution error on auth retry:", err)
 			w.WriteHeader(500)
 			w.Write([]byte(err.Error()))
 			return
 		}
-		// Close the connection to reuse it
+		// Close the response to reuse the connection
 		defer r.Body.Close()
 
 		// Store cookies per user and request host
@@ -108,14 +113,14 @@ func (p *Proxy) Handler(w http.ResponseWriter, req *http.Request) {
 			// Should store cookies based on domain value AND path from cookie
 			cookies[user] = map[string][]*http.Cookie{}
 			cookies[user][req.Host] = r.Cookies()
-			Logger.Printf("Cookies: %+v\n", cookies)
+			p.Log.Printf("Cookies: %+v\n", cookies)
 			cookiesL.Unlock()
 		}
-		Logger.Println("Resource "+authenticated.URL.String(),
+		p.Log.Println("Resource "+authenticated.URL.String(),
 			"requires authentication (HTTP 401).", solutionMsg,
 			"resulted in HTTP", r.StatusCode)
 
-		Logger.Println("Got authenticated response code:", r.StatusCode)
+		p.Log.Println("Got authenticated response code:", r.StatusCode)
 		w.Header().Set("Authenticated-Request", "1")
 	}
 
@@ -137,7 +142,7 @@ func (p *Proxy) Handler(w http.ResponseWriter, req *http.Request) {
 	body, _ := ioutil.ReadAll(r.Body)
 	w.Write(body)
 
-	Logger.Println("Received public data with status HTTP", r.StatusCode)
+	p.Log.Println("Received public data with status HTTP", r.StatusCode)
 	return
 }
 
@@ -154,6 +159,7 @@ func NewClient(skip bool) *http.Client {
 }
 
 func NewAgentClient(cert *tls.Certificate, skip bool) *http.Client {
+	//TODO handle bad/missing cert
 	return &http.Client{
 		Transport: &http.Transport{
 			MaxIdleConnsPerHost: MaxIdleConnections,
@@ -166,7 +172,7 @@ func NewAgentClient(cert *tls.Certificate, skip bool) *http.Client {
 	}
 }
 
-func TimeTrack(start time.Time, name string) {
+func TimeTrack(start time.Time, name string, logger *log.Logger) {
 	elapsed := time.Since(start)
-	Logger.Printf("%s finished in %s", name, elapsed)
+	logger.Printf("%s finished in %s", name, elapsed)
 }

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -110,7 +110,7 @@ func TestProxyNoSkipVerify(t *testing.T) {
 	skip := false
 	conf := NewServerConfig()
 	conf.InsecureSkipVerify = skip
-	agent, err := NewAgent(testAgentWebID)
+	agent, err := NewAgentLocal(testAgentWebID)
 	assert.NoError(t, err)
 	proxy := NewProxy(agent, skip)
 
@@ -127,6 +127,24 @@ func TestProxyNoSkipVerify(t *testing.T) {
 }
 
 func TestProxyNoUser(t *testing.T) {
+	conf := NewServerConfig()
+	agent, err := NewAgentLocal(testAgentWebID)
+	assert.NoError(t, err)
+	proxy := NewProxy(agent, true)
+
+	handler := NewProxyHandler(conf, proxy)
+	// testProxyServer
+	server := httptest.NewServer(handler)
+	server.URL = strings.Replace(server.URL, "127.0.0.1", "localhost", 1)
+
+	req, err := http.NewRequest("GET", server.URL+"/proxy?uri="+testMockServer.URL+"/401", nil)
+	assert.NoError(t, err)
+	resp, err := testClient.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 401, resp.StatusCode)
+}
+
+func TestProxyNoAgent(t *testing.T) {
 	conf := NewServerConfig()
 	agent, err := NewAgent(testAgentWebID)
 	assert.NoError(t, err)

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -107,10 +107,14 @@ func TestProxyBadRequest(t *testing.T) {
 }
 
 func TestProxyNoSkipVerify(t *testing.T) {
+	skip := false
 	conf := NewServerConfig()
-	conf.InsecureSkipVerify = false
+	conf.InsecureSkipVerify = skip
+	agent, err := NewAgent(testAgentWebID)
+	assert.NoError(t, err)
+	proxy := NewProxy(agent, skip)
 
-	handler := NewProxyHandler(conf)
+	handler := NewProxyHandler(conf, proxy)
 	// testProxyServer
 	server := httptest.NewServer(handler)
 	server.URL = strings.Replace(server.URL, "127.0.0.1", "localhost", 1)
@@ -124,8 +128,11 @@ func TestProxyNoSkipVerify(t *testing.T) {
 
 func TestProxyNoUser(t *testing.T) {
 	conf := NewServerConfig()
+	agent, err := NewAgent(testAgentWebID)
+	assert.NoError(t, err)
+	proxy := NewProxy(agent, true)
 
-	handler := NewProxyHandler(conf)
+	handler := NewProxyHandler(conf, proxy)
 	// testProxyServer
 	server := httptest.NewServer(handler)
 	server.URL = strings.Replace(server.URL, "127.0.0.1", "localhost", 1)

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -172,7 +172,7 @@ func TestProxyBadRequest(t *testing.T) {
 	assert.NoError(t, err)
 	resp, err := testClient.Do(req)
 	assert.NoError(t, err)
-	assert.Equal(t, 405, resp.StatusCode)
+	assert.Equal(t, 400, resp.StatusCode)
 }
 
 func TestProxyNoSkipVerify(t *testing.T) {

--- a/webid.go
+++ b/webid.go
@@ -42,14 +42,19 @@ func NewAgent(uri string) (*Agent, error) {
 	return agent, nil
 }
 
-func NewAgentLocal(uri string) (*Agent, error) {
+func NewAgentLocal(uri string, bits ...int) (*Agent, error) {
 	agent, err := NewAgent(uri)
 	if err != nil {
 		return agent, err
 	}
 
+	keyLen := rsaBits
+	if len(bits) > 0 {
+		keyLen = bits[0]
+	}
+
 	// Create a new keypair
-	privKey, E, N, err := NewRSAKey()
+	privKey, E, N, err := NewRSAKey(keyLen)
 	if err != nil {
 		return agent, err
 	}
@@ -61,9 +66,9 @@ func NewAgentLocal(uri string) (*Agent, error) {
 	return agent, nil
 }
 
-func NewRSAKey() (*rsa.PrivateKey, string, string, error) {
+func NewRSAKey(bits int) (*rsa.PrivateKey, string, string, error) {
 	var e, n string
-	p, err := rsa.GenerateKey(rand.Reader, rsaBits)
+	p, err := rsa.GenerateKey(rand.Reader, bits)
 	if err != nil {
 		return p, e, n, err
 	}

--- a/webid_test.go
+++ b/webid_test.go
@@ -12,11 +12,16 @@ import (
 )
 
 func TestNewRSAKey(t *testing.T) {
-	p, e, n, err := NewRSAKey()
+	p, e, n, err := NewRSAKey(rsaBits)
 	assert.NoError(t, err)
 	assert.IsType(t, new(rsa.PrivateKey), p)
 	assert.Equal(t, fmt.Sprintf("%d", p.PublicKey.E), e)
 	assert.NotEmpty(t, fmt.Sprintf("%x", p.PublicKey.N), n)
+}
+
+func TestNewRSAKeyError(t *testing.T) {
+	_, _, _, err := NewRSAKey(0)
+	assert.Error(t, err)
 }
 
 func TestNewAgent(t *testing.T) {
@@ -37,8 +42,13 @@ func TestNewAgentLocalEmptyURI(t *testing.T) {
 	assert.Empty(t, agent.WebID)
 }
 
+func TestNewAgentLocalBadKey(t *testing.T) {
+	_, err := NewAgentLocal(testAgentWebID, 0)
+	assert.Error(t, err)
+}
+
 func TestNewRSAcert(t *testing.T) {
-	p, _, _, err := NewRSAKey()
+	p, _, _, err := NewRSAKey(rsaBits)
 	assert.NoError(t, err)
 	cert, err := NewRSAcert(testAgentWebID, "Solid Proxy Agent", p)
 	assert.NoError(t, err)

--- a/webid_test.go
+++ b/webid_test.go
@@ -19,21 +19,33 @@ func TestNewRSAKey(t *testing.T) {
 	assert.NotEmpty(t, fmt.Sprintf("%x", p.PublicKey.N), n)
 }
 
-func TestNewAgentProfile(t *testing.T) {
-	// p := NewAgentProfile()
+func TestNewAgent(t *testing.T) {
+	agent, err := NewAgent(testAgentWebID)
+	assert.NoError(t, err)
+	assert.Equal(t, agent.WebID, testAgentWebID)
+}
 
+func TestNewAgentEmptyURI(t *testing.T) {
+	agent, err := NewAgent("")
+	assert.Error(t, err)
+	assert.Empty(t, agent.WebID)
+}
+
+func TestNewAgentLocalEmptyURI(t *testing.T) {
+	agent, err := NewAgentLocal("")
+	assert.Error(t, err)
+	assert.Empty(t, agent.WebID)
 }
 
 func TestNewRSAcert(t *testing.T) {
-	agentW := "https://agent.com/webid#me"
 	p, _, _, err := NewRSAKey()
 	assert.NoError(t, err)
-	cert, err := NewRSAcert(agentW, "Solid Proxy Agent", p)
+	cert, err := NewRSAcert(testAgentWebID, "Solid Proxy Agent", p)
 	assert.NoError(t, err)
 
 	webid, err := WebIDFromCert(cert.Certificate[0])
 	assert.NoError(t, err)
-	assert.Equal(t, "URI: "+agentW, webid)
+	assert.Equal(t, "URI: "+testAgentWebID, webid)
 }
 
 func WebIDFromCert(cert []byte) (string, error) {


### PR DESCRIPTION
This PR implemented #11 and #12. More precisely, it fixes usage of global variables between proxy functions and the HTTP handlers, as well as allows to persist connections to other servers by reusing HTTP handlers.

As a nice side-effect, this PR also turns `solidproxy` into a standalone library.