### PR TITLE
fixes #18

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -12,6 +12,9 @@ import (
 var (
 	cookies  = map[string]map[string][]*http.Cookie{}
 	cookiesL = new(sync.RWMutex)
+
+	credentials  = map[string]bool{}
+	credentialsL = new(sync.RWMutex)
 )
 
 func InitLogger(verbose bool) *log.Logger {

--- a/handler_test.go
+++ b/handler_test.go
@@ -20,6 +20,7 @@ var (
 func init() {
 	var err error
 	skipVerify := true
+	debug := false
 
 	testAgentWebID = "https://example.com/webid#me"
 
@@ -46,7 +47,9 @@ func init() {
 	proxy := NewProxy(agent, skipVerify)
 	proxyConf := NewServerConfig()
 	proxyConf.InsecureSkipVerify = skipVerify
+	proxyConf.Verbose = debug
 	proxyConf.Agent = testAgentWebID
+	proxyConf.Verbose = debug
 	proxyServer := NewProxyHandler(proxyConf, proxy)
 
 	// testProxyServer

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -189,7 +189,7 @@ func TestProxyAuthenticated(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 
-	// retry with cookie
+	// retry with cookie and try to remember if we have to auth from the start
 	req, err = http.NewRequest("GET", testProxyServer.URL+"/proxy?uri="+testMockServer.URL+"/401", nil)
 	assert.NoError(t, err)
 	req.Header.Set("User", alice)

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -165,37 +165,37 @@ func TestProxyHeaders(t *testing.T) {
 	assert.Equal(t, origin, resp.Header.Get("Access-Control-Allow-Origin"))
 }
 
+func TestProxyAuthenticated(t *testing.T) {
+	alice := "https://alice.com/profile#me"
+
+	req, err := http.NewRequest("GET", testProxyServer.URL+"/proxy?uri="+testMockServer.URL+"/401", nil)
+	assert.NoError(t, err)
+	req.Header.Set("User", alice)
+	resp, err := testClient.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// retry with cookie
+	req, err = http.NewRequest("GET", testProxyServer.URL+"/proxy?uri="+testMockServer.URL+"/401", nil)
+	assert.NoError(t, err)
+	req.Header.Set("User", alice)
+	resp, err = testClient.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+}
+
 func TestProxyNotAuthenticated(t *testing.T) {
 	req, err := http.NewRequest("GET", testProxyServer.URL+"/proxy?uri="+testMockServer.URL+"/200", nil)
 	assert.NoError(t, err)
 	resp, err := testClient.Do(req)
 	assert.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
-}
 
-func TestProxyAuthenticated(t *testing.T) {
-	alice := "https://alice.com/profile#me"
-
-	req, err := http.NewRequest("GET", testProxyServer.URL+"/proxy?uri="+testMockServer.URL+"/401", nil)
+	req, err = http.NewRequest("GET", testProxyServer.URL+"/proxy?uri="+testMockServer.URL+"/401", nil)
 	assert.NoError(t, err)
-	resp, err := testClient.Do(req)
+	resp, err = testClient.Do(req)
 	assert.NoError(t, err)
 	assert.Equal(t, 401, resp.StatusCode)
-
-	req, err = http.NewRequest("GET", testProxyServer.URL+"/proxy?uri="+testMockServer.URL+"/401", nil)
-	assert.NoError(t, err)
-	req.Header.Set("User", alice)
-	resp, err = testClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, resp.StatusCode)
-
-	// retry with cookie and try to remember if we have to auth from the start
-	req, err = http.NewRequest("GET", testProxyServer.URL+"/proxy?uri="+testMockServer.URL+"/401", nil)
-	assert.NoError(t, err)
-	req.Header.Set("User", alice)
-	resp, err = testClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, resp.StatusCode)
 }
 
 func TestProxyBadURLParse(t *testing.T) {

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -72,6 +72,7 @@ func MockServer() http.Handler {
 			http.SetCookie(w, cookie)
 			w.WriteHeader(200)
 			w.Header().Set("User", webid)
+			w.Write([]byte("foo"))
 			return
 		}
 
@@ -173,6 +174,9 @@ func TestProxyAuthenticated(t *testing.T) {
 	req.Header.Set("User", alice)
 	resp, err := testClient.Do(req)
 	assert.NoError(t, err)
+	body, err := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	assert.Equal(t, "foo", string(body))
 	assert.Equal(t, 200, resp.StatusCode)
 
 	// retry with cookie
@@ -181,6 +185,9 @@ func TestProxyAuthenticated(t *testing.T) {
 	req.Header.Set("User", alice)
 	resp, err = testClient.Do(req)
 	assert.NoError(t, err)
+	body, err = ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	assert.Equal(t, "foo", string(body))
 	assert.Equal(t, 200, resp.StatusCode)
 }
 


### PR DESCRIPTION
Requests that fail with `HTTP 401` will now save the fact that a URI required authentication, thus avoiding an extra round-trip without authentication for subsequent requests to that URI.