### PR TITLE
Cleanup after issue18

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -6,15 +6,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"sync"
-)
-
-var (
-	cookies  = map[string]map[string][]*http.Cookie{}
-	cookiesL = new(sync.RWMutex)
-
-	credentials  = map[string]bool{}
-	credentialsL = new(sync.RWMutex)
 )
 
 func InitLogger(verbose bool) *log.Logger {

--- a/proxy.go
+++ b/proxy.go
@@ -188,7 +188,6 @@ func (p *Proxy) NewRequest(req *http.Request, user string, authenticated bool) (
 	return r, err
 }
 
-//@TODO add a forgetUri() method that deletes the cache
 func rememberUri(uri string) bool {
 	if !privateUris[uri] {
 		privateUrisL.Lock()

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -13,6 +13,7 @@ import (
 
 var (
 	testMockServer *httptest.Server
+	testUri        = "https://example.org"
 )
 
 func init() {
@@ -283,4 +284,17 @@ func TestProxyNoAgent(t *testing.T) {
 	resp, err := testClient.Do(req)
 	assert.NoError(t, err)
 	assert.Equal(t, 401, resp.StatusCode)
+}
+
+func TestRememberUri(t *testing.T) {
+	assert.True(t, rememberUri(testUri))
+}
+
+func TestRequiresAuth(t *testing.T) {
+	assert.True(t, requiresAuth(testUri))
+}
+
+func TestForgetUri(t *testing.T) {
+	assert.True(t, forgetUri(testUri))
+	assert.False(t, requiresAuth(testUri))
 }


### PR DESCRIPTION
 * moved the global locks to the right file
 * added new function to remove a cached URI from the list if it became public
 * added more tests
